### PR TITLE
Allow vulnerability tests to specify the architectures which they support

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/util/CPUArch.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/util/CPUArch.java
@@ -1,0 +1,9 @@
+package fuzion24.device.vulnerability.util;
+
+public enum CPUArch {
+    ARM7,
+    ARM8,
+    X86,
+    X64,
+    ALL
+}

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/VulnerabilityTest.java
@@ -1,8 +1,11 @@
 package fuzion24.device.vulnerability.vulnerabilities;
 
 import android.content.Context;
+import java.util.List;
+import fuzion24.device.vulnerability.util.CPUArch;
 
 public interface VulnerabilityTest {
    public String getName();
    public boolean isVulnerable(Context context) throws Exception;
+   public List<CPUArch> getSupportedArchitectures();
 }

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/graphics/GraphicBufferTest.java
@@ -4,6 +4,10 @@ import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 /**
@@ -36,6 +40,14 @@ public class GraphicBufferTest implements VulnerabilityTest {
     @Override
     public String getName() {
         return "CVE-2015-1528/GraphicsBuffer Unflatten";
+    }
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
     }
 
     private native int checkGraphicsBuffer(int ver);

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/jar/JarBug13678484.java
@@ -1,9 +1,13 @@
 package fuzion24.device.vulnerability.vulnerabilities.framework.jar;
 
 import android.content.Context;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 // https://android.googlesource.com/platform/libcore/+/cb11b9fff2a1af8bb4fcad18986003a7f59189c6 //Tests
 // https://android.googlesource.com/platform/libcore/+/2bc5e811a817a8c667bca4318ae98582b0ee6dc6 //Fix
@@ -12,6 +16,13 @@ import java.io.File;
 
 
 public class JarBug13678484 implements VulnerabilityTest {
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/CVE_2015_6602.java
@@ -5,7 +5,10 @@ import android.util.Log;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 import fuzion24.device.vulnerability.vulnerabilities.helper.TestResult;
 
@@ -17,6 +20,14 @@ public class CVE_2015_6602 implements VulnerabilityTest {
     private static final String TAG = "cve-2015-6602";
 
     public CVE_2015_6602() {}
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/media/StageFright.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 import fuzion24.device.vulnerability.vulnerabilities.helper.TestResult;
 
@@ -60,6 +61,13 @@ public class StageFright {
                     @Override
                     public String getName() {
                         return "StageFright: " + FilenameUtils.removeExtension(mediaFile);
+                    }
+
+                    @Override
+                    public List<CPUArch> getSupportedArchitectures() {
+                        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+                        archs.add(CPUArch.ARM7);
+                        return null;
                     }
 
                     @Override

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/securerandom/SecureRandomTest.java
@@ -4,7 +4,10 @@ import android.content.Context;
 import android.util.Log;
 
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class SecureRandomTest implements VulnerabilityTest{
@@ -20,6 +23,15 @@ public class SecureRandomTest implements VulnerabilityTest{
     public String getName() {
         return "CVE-2013-7372";
     }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
+
 
     @Override
     public boolean isVulnerable(Context context) throws Exception {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/ObjectSerializationBugTest.java
@@ -8,7 +8,10 @@ import java.io.ObjectStreamClass;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
 import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class ObjectSerializationBugTest implements VulnerabilityTest{
@@ -21,6 +24,14 @@ public class ObjectSerializationBugTest implements VulnerabilityTest{
     public String getName() {
         return "CVE-2014-7911";
     }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
 
     @Override
     public boolean isVulnerable(Context context) throws Exception {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/OpenSSLTransientBug.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/serialization/OpenSSLTransientBug.java
@@ -11,6 +11,8 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 
 //Some code was borrowed from AOSP
@@ -29,6 +31,7 @@ import java.lang.reflect.Method;
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 /**
@@ -57,6 +60,13 @@ public class OpenSSLTransientBug implements VulnerabilityTest {
     @Override
     public String getName() {
         return "OpenSSL509 Serialization Bug : CVE-2015-3825";
+    }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
     }
 
     @Override

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug8219321.java
@@ -6,14 +6,24 @@ import android.content.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class ZipBug8219321 implements VulnerabilityTest {
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
 
     public String getName(){
         return "ZipBug 8219321";

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9695860.java
@@ -16,6 +16,7 @@ import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class ZipBug9695860 implements VulnerabilityTest {
@@ -27,6 +28,14 @@ public class ZipBug9695860 implements VulnerabilityTest {
         return "ZipBug 9695860";
     }
 
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
 
     private long getCRC(byte[]data){
         CRC32 crc = new CRC32();

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/framework/zip/ZipBug9950697.java
@@ -16,6 +16,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 /*
@@ -29,6 +30,13 @@ public class ZipBug9950697 implements VulnerabilityTest {
 
     public String getName(){
         return "ZipBug 9950697";
+    }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
     }
 
     public boolean isVulnerable(Context context) throws Exception {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2011_1149.java
@@ -2,12 +2,25 @@ package fuzion24.device.vulnerability.vulnerabilities.kernel;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class CVE_2011_1149 implements VulnerabilityTest {
     static {
         System.loadLibrary("cve-2011-1149");
     }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
+
 
     /*
         Fixes:

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6123.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2013_6123.java
@@ -2,12 +2,26 @@ package fuzion24.device.vulnerability.vulnerabilities.kernel;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class CVE_2013_6123 implements VulnerabilityTest {
    static {
      System.loadLibrary("cve-2013-6123");
    }
+
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_3153.java
@@ -2,12 +2,26 @@ package fuzion24.device.vulnerability.vulnerabilities.kernel;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class CVE_2014_3153 implements VulnerabilityTest {
     static {
         System.loadLibrary("cve-2014-3153");
     }
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2014_4943.java
@@ -2,12 +2,26 @@ package fuzion24.device.vulnerability.vulnerabilities.kernel;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class CVE_2014_4943 implements VulnerabilityTest {
     static {
         System.loadLibrary("CVE-2014-4943");
     }
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/kernel/CVE_2015_3636.java
@@ -2,6 +2,10 @@ package fuzion24.device.vulnerability.vulnerabilities.kernel;
 
 import android.content.Context;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 /**
@@ -21,6 +25,14 @@ public class CVE_2015_3636 implements VulnerabilityTest {
     public String getName() {
         return "CVE-2015-3636/pingpong";
     }
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ARM7);
+        return null;
+    }
+
 
     private native int checkPingPong();
 

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/SamsungCREDzip.java
@@ -11,8 +11,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import java.lang.Thread;
+import java.util.ArrayList;
+import java.util.List;
+
 import android.os.Build;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 public class SamsungCREDzip implements VulnerabilityTest {
@@ -21,6 +25,15 @@ public class SamsungCREDzip implements VulnerabilityTest {
     private final static String DESTINATION = "/sdcard/Download/";
     private final static String FILENAME = "cred.zip";
     private final static String ASSETNAME = "Samsung_cred.zip";
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/StumpRoot.java
@@ -4,14 +4,26 @@ import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 public class StumpRoot implements VulnerabilityTest  {
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/WeakSauce.java
@@ -4,11 +4,23 @@ package fuzion24.device.vulnerability.vulnerabilities.system;
 import android.content.Context;
 import android.content.pm.PackageManager;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class WeakSauce implements VulnerabilityTest {
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
 
     @Override
     public String getName() {

--- a/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/vulnerabilities/system/ZergRush.java
@@ -4,7 +4,10 @@ import android.content.Context;
 import android.os.storage.StorageManager;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
+import fuzion24.device.vulnerability.util.CPUArch;
 import fuzion24.device.vulnerability.vulnerabilities.VulnerabilityTest;
 import fuzion24.device.vulnerability.vulnerabilities.helper.Proc;
 
@@ -13,6 +16,15 @@ public class ZergRush implements VulnerabilityTest {
     public String getName() {
         return null;
     }
+
+
+    @Override
+    public List<CPUArch> getSupportedArchitectures() {
+        ArrayList<CPUArch> archs = new ArrayList<CPUArch>();
+        archs.add(CPUArch.ALL);
+        return null;
+    }
+
 
     @Override
     public boolean isVulnerable(Context context) throws Exception {


### PR DESCRIPTION
This closes #27 <Check architecture support>