### PR TITLE
Add "Share for Research" action

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/test/ShareViaGoogleForm.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/test/ShareViaGoogleForm.java
@@ -1,0 +1,62 @@
+package fuzion24.device.vulnerability.test;
+
+
+import android.net.Uri;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+public class ShareViaGoogleForm {
+    private static final String mFormUrl;
+    private static Map<String, String> submitMapping = new HashMap<>();
+    private final JSONObject mCombinedResults;
+
+    static {
+        mFormUrl = "https://docs.google.com/forms/d/1hAoRFCmPmIEzKD_gQBZhne2Jkr24E5VTuI_yGXKnVyE/formResponse";
+
+        submitMapping.put("fingerprint", "entry.957780611");
+        submitMapping.put("kernelVersion", "entry.173229528");
+        submitMapping.put("brand", "entry.1413588413");
+        submitMapping.put("manufacturer", "entry.2048857005");
+        submitMapping.put("model", "entry.2054096086");
+        submitMapping.put("release", "entry.1474130928");
+        submitMapping.put("sdk", "entry.1701379105");
+        submitMapping.put("versionCode", "entry.275175001");
+        submitMapping.put("versionName", "entry.506488905");
+        submitMapping.put("id", "entry.218715471");
+        submitMapping.put("combinedResults", "entry.2112177772");
+
+    }
+
+    public ShareViaGoogleForm(JSONObject combinedResults) {
+        mCombinedResults = combinedResults;
+    }
+
+    public Uri buildUri() throws JSONException {
+        JSONObject buildInfo = mCombinedResults.getJSONObject("buildInfo");
+        Uri.Builder builder = Uri.parse(mFormUrl).buildUpon();
+
+        Iterator<String> keys = buildInfo.keys();
+        while (keys.hasNext()) {
+            String curKey = keys.next();
+            if (!submitMapping.containsKey(curKey)) {
+                continue;
+            }
+
+            String result = buildInfo.getString(curKey);
+            String formKey = submitMapping.get(curKey);
+            builder.appendQueryParameter(formKey, result);
+        }
+
+        // lastly put the JSON string as the combinedResults form value
+        String combinedResultsFormKey = submitMapping.get("combinedResults");
+        String results = mCombinedResults.toString();
+        builder.appendQueryParameter(combinedResultsFormKey, results);
+
+        return builder.build();
+    }
+}

--- a/app/src/main/java/fuzion24/device/vulnerability/test/ui/MainActivity.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/test/ui/MainActivity.java
@@ -3,6 +3,7 @@ package fuzion24.device.vulnerability.test.ui;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
@@ -27,6 +28,7 @@ import org.json.JSONObject;
 import java.util.List;
 
 import fuzion24.device.vulnerability.test.ResultsCallback;
+import fuzion24.device.vulnerability.test.ShareViaGoogleForm;
 import fuzion24.device.vulnerability.test.VulnerabilityTestResult;
 import fuzion24.device.vulnerability.test.VulnerabilityTestRunner;
 import fuzion24.device.vulnerability.test.adapter.RecyclerAdapter;
@@ -94,9 +96,11 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.menu_export_results:
+        int itemId = item.getItemId();
 
+        switch (itemId) {
+            case R.id.menu_export_results:
+            case R.id.menu_share_results:
                 if (testResults == null) {
                     Snackbar.make(coordinatorLayout, R.string.run_tests, Snackbar.LENGTH_LONG).setAction(R.string.start, new View.OnClickListener() {
                         @Override
@@ -105,22 +109,29 @@ public class MainActivity extends AppCompatActivity {
                         }
 
                     }).show();
-
+                    
                     return true;
                 }
 
-                Intent shareIntent = new Intent(Intent.ACTION_SEND);
-
-                shareIntent.setType("text/plain");
-                shareIntent.putExtra(Intent.EXTRA_SUBJECT, "Android VTS Results");
+                Intent intent = null;
                 try {
                     JSONObject json = serializeResults(testResults, devInfo);
-                    shareIntent.putExtra(Intent.EXTRA_TEXT, json.toString(4));
-
-                    startActivity(Intent.createChooser(shareIntent, getString(R.string.share_results_via)));
+                    if (itemId == R.id.menu_export_results) {
+                        intent = new Intent(Intent.ACTION_SEND);
+                        intent.setType("text/plain");
+                        intent.putExtra(Intent.EXTRA_SUBJECT, "Android VTS Results");
+                        intent.putExtra(Intent.EXTRA_TEXT, json.toString(4));
+                    } else if(itemId == R.id.menu_share_results) {
+                        Uri formUri = new ShareViaGoogleForm(json).buildUri();
+                        intent = new Intent(Intent.ACTION_VIEW, formUri);
+                    }
                 } catch (JSONException e) {
                     Log.d(TAG, "Json exception: " + e.getMessage());
                     Snackbar.make(coordinatorLayout, R.string.error_exporting_results, Snackbar.LENGTH_LONG).show();
+                }
+
+                if (intent != null) {
+                    startActivity(Intent.createChooser(intent, getString(R.string.share_results_via)));
                 }
 
                 return true;

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -7,4 +7,9 @@
         android:title="@string/export_results"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/menu_share_results"
+        android:title="@string/submit_results"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="test_result_success">Not Vulnerable</string>
     <string name="test_result_failure">Vulnerable</string>
     <string name="export_results">Export results</string>
+    <string name="submit_results">Share for Research</string>
     <string name="share_results_via">Share results via</string>
     <string name="error_exporting_results">Error exporting the results.</string>
     <string name="run_tests">Please run the tests first</string>


### PR DESCRIPTION
- closes #6
- adds an action option to share results via a Google Form (https URL)
- the user will be prompted to select a suitable application to handle the
  URL which encodes the device build info, and vulnerability results.
- the users will be able to see previous responses from others.

cc @SandroMachado 