### PR TITLE
Add a scan resume dialog

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/test/ui/MainActivity.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/test/ui/MainActivity.java
@@ -18,10 +18,10 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
-import com.nowsecure.android.vts.BuildConfig;
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.nowsecure.android.vts.R;
 
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -60,7 +60,7 @@ public class MainActivity extends AppCompatActivity {
         getSupportActionBar().setTitle(R.string.app_name);
 
         if (savedInstanceState != null && savedInstanceState.containsKey(SERIALIZABLE_RESULTS)) {
-            testResults =  (ArrayList<VulnerabilityTestResult>) savedInstanceState.getSerializable(SERIALIZABLE_RESULTS);
+            testResults = (ArrayList<VulnerabilityTestResult>) savedInstanceState.getSerializable(SERIALIZABLE_RESULTS);
         } else {
             testResults = new ArrayList<>();
         }
@@ -95,7 +95,7 @@ public class MainActivity extends AppCompatActivity {
         tvBuildSDK.setText(devInfo.getBuildSDK());
 
         StringBuilder sb = new StringBuilder();
-        for(String s : devInfo.getSupportedABIS()){
+        for (String s : devInfo.getSupportedABIS()) {
             sb.append(s);
             sb.append(" ");
         }
@@ -134,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
                         }
 
                     }).show();
-                    
+
                     return true;
                 }
 
@@ -146,7 +146,7 @@ public class MainActivity extends AppCompatActivity {
                         intent.setType("text/plain");
                         intent.putExtra(Intent.EXTRA_SUBJECT, "Android VTS Results");
                         intent.putExtra(Intent.EXTRA_TEXT, json.toString(4));
-                    } else if(itemId == R.id.menu_share_results) {
+                    } else if (itemId == R.id.menu_share_results) {
                         Uri formUri = new ShareViaGoogleForm(json).buildUri();
                         intent = new Intent(Intent.ACTION_VIEW, formUri);
                     }
@@ -177,8 +177,57 @@ public class MainActivity extends AppCompatActivity {
 
                 emptyView.setVisibility(View.GONE);
                 recyclerAdapter.updateResults(results);
+
+                showScanResume(results);
             }
         }).execute();
+    }
+
+    private void showScanResume(final List<VulnerabilityTestResult> results) {
+        int numberOfFailed = 0;
+
+        for (VulnerabilityTestResult result : results) {
+            if (result.getException() != null) {
+                continue;
+            }
+
+            if (result.isVulnerable()) {
+                numberOfFailed++;
+            }
+        }
+
+        MaterialDialog.Builder dialogBuilder = new MaterialDialog.Builder(this)
+            .title(R.string.scan_details)
+            .customView(R.layout.dialog_scan_details_layout, true)
+            .positiveText(R.string.dismiss);
+
+        if (numberOfFailed > 0) {
+            dialogBuilder.negativeText(R.string.my_device_is_vulnerable_info)
+                .onNegative(new MaterialDialog.SingleButtonCallback() {
+                    @Override
+                    public void onClick(MaterialDialog materialDialog, DialogAction dialogAction) {
+                        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.nowsecure.com/blog/2015/11/18/my-device-is-vulnerable-now-what/"));
+                        startActivity(browserIntent);
+                    }
+                });
+        }
+
+        View view = dialogBuilder.show().getCustomView();
+
+        TextView state = (TextView) view.findViewById(R.id.scan_details_device_state);
+        if (numberOfFailed > 0) {
+            state.setText(R.string.scan_details_vulnerable_message);
+            state.setTextColor(getResources().getColor(R.color.red));
+        } else {
+            state.setText(R.string.scan_details_secure_message);
+            state.setTextColor(getResources().getColor(R.color.green));
+        }
+
+        TextView numberOfTests = (TextView) view.findViewById(R.id.scan_details_number_tests);
+        numberOfTests.setText(String.valueOf(results.size()));
+
+        TextView numberOfFailedTests = (TextView) view.findViewById(R.id.scan_details_failed_tests);
+        numberOfFailedTests.setText(String.valueOf(numberOfFailed));
     }
 
     @Override

--- a/app/src/main/res/layout/dialog_scan_details_layout.xml
+++ b/app/src/main/res/layout/dialog_scan_details_layout.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/scan_details_device_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp"
+        android:text="@string/scan_details_secure_message"
+        android:textSize="18sp"
+        android:textStyle="bold"/>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingLeft="5dp"
+        android:paddingTop="2dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingRight="5dp"
+            android:text="@string/scan_details_number_tests"/>
+
+        <TextView
+            android:id="@+id/scan_details_number_tests"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="10"/>
+
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingLeft="5dp"
+        android:paddingTop="2dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingRight="5dp"
+            android:text="@string/scan_details_number_failed_tests"/>
+
+        <TextView
+            android:id="@+id/scan_details_failed_tests"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="10"/>
+
+    </LinearLayout>
+    
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,5 +35,11 @@
     <string name="cvssv2">CVSSV2: </string>
     <string name="cve_date">CVE Date: </string>
     <string name="notification_new_tests">New tests are available</string>
+    <string name="scan_details">Scan details</string>
+    <string name="my_device_is_vulnerable_info">Now What?</string>
+    <string name="scan_details_number_failed_tests">Number of failed tests:</string>
+    <string name="scan_details_number_tests">Number of tests:</string>
+    <string name="scan_details_secure_message">Your device is secure</string>
+    <string name="scan_details_vulnerable_message">Your device is vulnerable</string>
 
 </resources>


### PR DESCRIPTION
This PR will show a dialog at the end of each scan with the number of failed tests and the number of tests. Closes #77.

![device-2015-11-26-012308](https://cloud.githubusercontent.com/assets/631739/11413118/5ae52cae-93dd-11e5-9e97-f98765948f89.png)
![device-2015-11-26-012403](https://cloud.githubusercontent.com/assets/631739/11413119/5ae7ba14-93dd-11e5-84b9-0088b0b5c32d.png)
