### PR TITLE
Add a flag that controls whether an existing test was updated to notify the user

### DIFF
--- a/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ApplicationUpdateBroadcastReceiver.java
+++ b/app/src/main/java/fuzion24/device/vulnerability/broadcastreceiver/ApplicationUpdateBroadcastReceiver.java
@@ -29,6 +29,8 @@ public class ApplicationUpdateBroadcastReceiver extends BroadcastReceiver {
 
     private static final int NOTIFICATION_ID = 1;
 
+    private static final boolean mTestWasChanged = false;
+
     @Override
     public void onReceive(final Context context, final Intent intent) {
         List<String> currentTestsAvailable = new ArrayList<>();
@@ -41,7 +43,7 @@ public class ApplicationUpdateBroadcastReceiver extends BroadcastReceiver {
 
         // First run, save the current list of scans.
         if (testsAvailableOnPreviousBuild == null) {
-            Log.d(TAG, "This is the  first time this detection is running.");
+            Log.d(TAG, "This is the first time this detection is running.");
             SharedPreferencesUtils.setTheListOfScansAvailable(context, currentTestsAvailable);
 
             return;
@@ -50,11 +52,16 @@ public class ApplicationUpdateBroadcastReceiver extends BroadcastReceiver {
         // Update application with the tests available.
         SharedPreferencesUtils.setTheListOfScansAvailable(context, currentTestsAvailable);
 
+        if(mTestWasChanged){
+            buildNotification(context, false);
+            Log.d(TAG, "An existing test was updated");
+        }
+
         for (String testName : currentTestsAvailable) {
             if (!testsAvailableOnPreviousBuild.contains(testName)) {
 
                 // This test is new, show a notification to the user.
-                buildNotification(context);
+                buildNotification(context, true);
                 Log.d(TAG, String.format("New test available:, %s", testName));
 
                 return;
@@ -64,11 +71,12 @@ public class ApplicationUpdateBroadcastReceiver extends BroadcastReceiver {
         Log.d(TAG, "Without new tests detected.");
     }
 
-    private void buildNotification(Context context) {
+    private void buildNotification(Context context, boolean forNewTest) {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context).setSmallIcon(R.drawable.ic_notification)
             .setAutoCancel(true)
             .setContentTitle(context.getString(R.string.app_name))
-            .setContentText(context.getString(R.string.notification_new_tests));
+            .setContentText(forNewTest ? context.getString(R.string.notification_new_tests) :
+                                         context.getString(R.string.existing_test_updated));
 
         Intent notificationIntent = new Intent(context, MainActivity.class);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="cvssv2">CVSSV2: </string>
     <string name="cve_date">CVE Date: </string>
     <string name="notification_new_tests">New tests are available</string>
+    <string name="existing_test_updated">An existing vulnerability test has been updated</string>
     <string name="scan_details">Scan details</string>
     <string name="my_device_is_vulnerable_info">Now What?</string>
     <string name="scan_details_number_failed_tests">Number of failed tests:</string>


### PR DESCRIPTION
closes #80 
Requires a developer to manually set the mTestWasChanged flag when an existing test is updated and to clear it on subsequent app update.